### PR TITLE
ASR Agent improvements

### DIFF
--- a/agents/asr/Dockerfile.asist
+++ b/agents/asr/Dockerfile.asist
@@ -1,9 +1,12 @@
-from python:3.7
+from python:3
+run apt update
+run apt -y install mosquitto-clients
 run pip install\
     six\
     websockets\
     numpy\
-    paho-mqtt\
     google-cloud-speech
 workdir asr
 copy * /asr/
+cmd ./tomcat_asr_agent websockets --ws_host 0.0.0.0 --ws_port 8888\
+    | mosquitto_pub -t agents/asr -l -h host.docker.internal

--- a/agents/asr/Dockerfile.asist
+++ b/agents/asr/Dockerfile.asist
@@ -2,7 +2,6 @@ from python:3
 run apt update
 run apt -y install mosquitto-clients
 run pip install\
-    six\
     websockets\
     numpy\
     google-cloud-speech

--- a/agents/asr/README.md
+++ b/agents/asr/README.md
@@ -19,17 +19,17 @@ Prerequisites
 
 - You'll need Python 3.6 or newer.
 - To access the microphone, you'll need the `pyaudio` package:
- 
+
       pip install pyaudio
 
     On Ubuntu, you'll need to install portaudio before installing pyaudio. You can do so with the following command:
 
-      sudo apt-get install portaudio19-dev 
+      sudo apt-get install portaudio19-dev
 
 ### Google Cloud engine
 
 If you are using the Google Cloud speech recognition engine:
-    
+
     pip install google-cloud-speech
 
 To use the Google Cloud Speech Recognition engine, you will need to point the
@@ -42,13 +42,6 @@ If you are using the PocketSphinx engine:
 
     ./install_pocketsphinx_python
 
-### MQTT message bus publishing
-
-If you enable publishing to an MQTT message bus (with the --use_mqtt
-option), you'll need to install the Eclipse Paho Python client library:
-
-    pip install paho-mqtt
-
 ### Websocket server mode
 
 To run the agent in the websocket server mode, you'll need the `websockets`
@@ -57,6 +50,7 @@ Python package (`pip install websockets`)
 Docker instructions
 -------------------
 
-You can launch a containerized version of the agent using Docker Compose:
+You can launch a containerized version of the agent that publishes to an MQTT
+message bus using Docker Compose:
 
     docker-compose up --build

--- a/agents/asr/asr_client.py
+++ b/agents/asr/asr_client.py
@@ -1,26 +1,15 @@
 import sys
 import json
 from dataclasses import asdict
-from paho.mqtt.client import Client as MQTTClient
 from messages import Data, Message, Msg
 
 
 class ASRClient(object):
     def __init__(
         self,
-        use_mqtt: bool = False,
-        mqtt_host="localhost",
-        mqtt_port=1883,
-        publish_topic="agents/asr",
         participant_id=None,
     ):
-        self.use_mqtt = use_mqtt
         self.participant_id = participant_id
-        if self.use_mqtt:
-            # Set up the Paho MQTT client.
-            self.mqtt_client = MQTTClient()
-            self.mqtt_client.connect(mqtt_host, mqtt_port)
-            self.publish_topic = publish_topic
 
     def publish_transcript(self, transcript, asr_system):
         ta3_data = Data(transcript, asr_system)
@@ -28,10 +17,7 @@ class ASRClient(object):
         json_message_str = json.dumps(
             asdict(Message(ta3_data, msg = msg))
         )
-        if self.use_mqtt:
-            self.mqtt_client.publish(self.publish_topic, json_message_str)
-        else:
-            print(json_message_str)
-            # We call sys.stdout.flush() to make this program work with piping,
-            # for example, through the jq program.
-            sys.stdout.flush()
+        print(json_message_str)
+        # We call sys.stdout.flush() to make this program work with piping,
+        # for example, through the jq program.
+        sys.stdout.flush()

--- a/agents/asr/audio_stream.py
+++ b/agents/asr/audio_stream.py
@@ -1,6 +1,8 @@
 import queue
 from utils import get_current_time
 
+GOOGLE_STREAMING_LIMIT = 240000  # 4 minutes
+
 class AudioStream(object):
     """Opens a stream as a generator that yields audio chunks."""
 

--- a/agents/asr/audio_stream.py
+++ b/agents/asr/audio_stream.py
@@ -1,4 +1,4 @@
-from six.moves import queue
+import queue
 from utils import get_current_time
 
 class AudioStream(object):

--- a/agents/asr/docker-compose.yml
+++ b/agents/asr/docker-compose.yml
@@ -13,11 +13,3 @@ services:
     volumes:
       - $GOOGLE_APPLICATION_CREDENTIALS:/google_application_credentials.json
       - .:/asr
-    entrypoint: [
-      "./tomcat_asr_agent",
-      "websockets",
-      "--use_mqtt",
-      "--ws_host", "0.0.0.0",
-      "--ws_port", "8888",
-      "--mqtt_host", "host.docker.internal"
-    ]

--- a/agents/asr/google_asr_client.py
+++ b/agents/asr/google_asr_client.py
@@ -18,14 +18,8 @@ class GoogleASRClient(ASRClient):
         rate: int,
         chunk_size: Optional[int] = None,
         participant_id=None,
-        use_mqtt: bool = False,
-        mqtt_host: str = "localhost",
-        mqtt_port: int = 1883,
     ):
         super().__init__(
-            use_mqtt=use_mqtt,
-            mqtt_host=mqtt_host,
-            mqtt_port=mqtt_port,
             participant_id=participant_id,
         )
         self.rate = rate

--- a/agents/asr/google_asr_client.py
+++ b/agents/asr/google_asr_client.py
@@ -22,9 +22,8 @@ class GoogleASRClient(ASRClient):
         super().__init__(
             participant_id=participant_id,
         )
-        self.rate = rate
         self.chunk_size = (
-            int(self.rate / 10) if chunk_size is None else chunk_size
+            int(rate / 10) if chunk_size is None else chunk_size
         )
         self.language_code = "en_US"
         self.speech_client = google.cloud.speech.SpeechClient()
@@ -38,8 +37,9 @@ class GoogleASRClient(ASRClient):
         recognition_config = google.cloud.speech.RecognitionConfig(
             audio_channel_count=1,
             encoding=google.cloud.speech.RecognitionConfig.AudioEncoding.LINEAR16,
-            sample_rate_hertz=self.rate,
+            sample_rate_hertz=rate,
             language_code=self.language_code,
+            enable_automatic_punctuation=True,
         )
 
         self.streaming_recognition_config = (
@@ -71,7 +71,6 @@ class GoogleASRClient(ASRClient):
                 )
 
                 self.listen_print_loop(responses)
-                info("Finished listen print loop")
 
                 if stream.result_end_time > 0:
                     stream.final_request_end_time = stream.is_final_end_time

--- a/agents/asr/tomcat_asr_agent
+++ b/agents/asr/tomcat_asr_agent
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     )
 
     parser_stdin.add_argument(
-        "sample_rate",
+        "--sample_rate",
         type=int,
         default=44100,
         help="Sample rate in Hertz of the raw input audio stream.",
@@ -150,7 +150,7 @@ if __name__ == "__main__":
     )
 
     parser_stdin.add_argument(
-        "chunk_size",
+        "--chunk_size",
         type=int,
         default=3200,
         help=(

--- a/agents/asr/tomcat_asr_agent
+++ b/agents/asr/tomcat_asr_agent
@@ -106,21 +106,17 @@ if __name__ == "__main__":
     )
 
     parser_stdin.add_argument(
-        "--sample_rate",
+        "sample_rate",
         type=int,
-        default=44100,
         help="Sample rate in Hertz of the raw input audio stream.",
-        nargs="?",
     )
 
     parser_stdin.add_argument(
-        "--chunk_size",
+        "chunk_size",
         type=int,
-        default=3200,
         help=(
             "Number of bytes to read at a time from the input audio stream."
         ),
-        nargs="?",
     )
 
     parser_microphone = subparsers.add_parser(
@@ -171,29 +167,29 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.WARNING)
 
     try:
         if args.mode == "stdin":
-            audio_stream = AudioStream()
-            asr_client = GoogleASRClient(
-                audio_stream,
-                args.sample_rate,
-                args.chunk_size,
-            )
-            asr_thread = threading.Thread(target=asr_client.run, daemon=True)
-            asr_thread.start()
+            with AudioStream() as audio_stream:
+                asr_client = GoogleASRClient(
+                    audio_stream,
+                    args.sample_rate,
+                    args.chunk_size,
+                )
+                asr_thread = threading.Thread(target=asr_client.run)
+                asr_thread.start()
 
-            while True:
-                data = sys.stdin.buffer.read(args.chunk_size)
-                if not data:
-                    time.sleep(1)
-                    audio_stream.closed = True
-                    asr_thread.join(timeout=1)
-                    break
-                else:
-                    chunk = float32_array_to_int16_array(data)
-                    audio_stream.fill_buffer(chunk)
+                while True:
+                    data = sys.stdin.buffer.read(args.chunk_size)
+                    if not data:
+                        break
+                    else:
+                        chunk = float32_array_to_int16_array(data)
+                        audio_stream.fill_buffer(chunk)
+
+                time.sleep(1)
+
 
         elif args.mode == "microphone":
             if args.engine == "google":

--- a/agents/asr/tomcat_asr_agent
+++ b/agents/asr/tomcat_asr_agent
@@ -175,7 +175,8 @@ if __name__ == "__main__":
                 asr_client = GoogleASRClient(
                     audio_stream,
                     args.sample_rate,
-                    args.chunk_size,
+                    # We divide by 2 since we assume 32 bit floats converted to 16 bit ints
+                    args.chunk_size/2,
                 )
                 asr_thread = threading.Thread(target=asr_client.run)
                 asr_thread.start()
@@ -187,6 +188,7 @@ if __name__ == "__main__":
                     else:
                         chunk = float32_array_to_int16_array(data)
                         audio_stream.fill_buffer(chunk)
+
 
                 time.sleep(1)
 

--- a/agents/asr/tomcat_asr_agent
+++ b/agents/asr/tomcat_asr_agent
@@ -36,9 +36,6 @@ RECORDING_IN_PROGRESS = True
 async def message_handler(
     websocket,
     path,
-    use_mqtt: bool = False,
-    mqtt_host: str = "localhost",
-    mqtt_port: int = 1883,
 ):
     query_params = parse_qs(urlparse(websocket.path).query)
 
@@ -58,9 +55,6 @@ async def message_handler(
         audio_stream,
         sample_rate,
         participant_id=participant_id,
-        use_mqtt=use_mqtt,
-        mqtt_host=mqtt_host,
-        mqtt_port=mqtt_port,
     )
     threading.Thread(target=asr_client.run, daemon=True).start()
 
@@ -94,36 +88,6 @@ if __name__ == "__main__":
     )
 
     parent_parser = ArgumentParser(add_help=False)
-    mqtt_options = parent_parser.add_argument_group("MQTT-related options")
-    mqtt_options.add_argument(
-        "--use_mqtt",
-        action="store_true",
-        help=(
-            "Publish messages to an MQTT message broker instead of printing "
-            "to standard output."
-        ),
-    )
-
-    mqtt_options.add_argument(
-        "--mqtt_host",
-        type=str,
-        default="localhost",
-        help="Host that the MQTT broker is running on.",
-    )
-
-    mqtt_options.add_argument(
-        "--mqtt_port",
-        type=int,
-        default=1883,
-        help="Port that the MQTT broker is running on.",
-    )
-
-    mqtt_options.add_argument(
-        "--publish_topic",
-        type=str,
-        help="Message bus topic to publish to.",
-        default="agents/asr_agent",
-    )
 
     # ==========================================
     # Adding subparsers for the different modes.
@@ -216,9 +180,6 @@ if __name__ == "__main__":
                 audio_stream,
                 args.sample_rate,
                 args.chunk_size,
-                use_mqtt=args.use_mqtt,
-                mqtt_host=args.mqtt_host,
-                mqtt_port=args.mqtt_port,
             )
             asr_thread = threading.Thread(target=asr_client.run, daemon=True)
             asr_thread.start()
@@ -244,9 +205,6 @@ if __name__ == "__main__":
                     asr_client = GoogleASRClient(
                         stream,
                         args.sample_rate,
-                        use_mqtt=args.use_mqtt,
-                        mqtt_host=args.mqtt_host,
-                        mqtt_port=args.mqtt_port,
                     )
                     asr_client.run()
             else:
@@ -263,12 +221,7 @@ if __name__ == "__main__":
 
             asyncio.gather(
                 websockets.serve(
-                    partial(
-                        message_handler,
-                        use_mqtt=args.use_mqtt,
-                        mqtt_host=args.mqtt_host,
-                        mqtt_port=args.mqtt_port,
-                    ),
+                    message_handler,
                     args.ws_host,
                     args.ws_port,
                 ),

--- a/agents/docker-compose.yml
+++ b/agents/docker-compose.yml
@@ -13,14 +13,6 @@ services:
     volumes:
       - $GOOGLE_APPLICATION_CREDENTIALS:/google_application_credentials.json
       - ./asr:/asr
-    entrypoint: [
-      "./tomcat_asr_agent",
-      "websockets",
-      "--use_mqtt",
-      "--ws_host", "0.0.0.0",
-      "--ws_port", "8888",
-      "--mqtt_host", "host.docker.internal"
-    ]
   webmic:
     image: webmic:latest
     container_name: webmic

--- a/agents/webmic/app.js
+++ b/agents/webmic/app.js
@@ -11,6 +11,11 @@ var config = {"destination_host" : "localhost", "destination_port" : 8888}
 const params = new URLSearchParams(window.location.search);
 const participantId = params.get("id");
 
+var processWebSocketMessage = function(event) {
+    document.getElementById("participantId").innerHTML =
+        "Participant ID: " + event.data;
+};
+
 function makeSocket(destination) {
     var ws = new WebSocket(destination);
 
@@ -23,10 +28,7 @@ function makeSocket(destination) {
         console.log("Websocket connected!")
     }
 
-    ws.onmessage = function(event) {
-        document.getElementById("participantId").innerHTML =
-            "Participant ID: " + event.data;
-    };
+    ws.onmessage = processWebSocketMessage;
 
     ws.onerror = (error) => {
         console.error(


### PR DESCRIPTION
This PR does the following:

- Removes the Eclipse Paho dependency (messages are now published in the Dockerized version using the `mosquitto_pub` client executable)
- Changes the default log level to `WARNING`
- Fixes a bug with a missing variable `GOOGLE_STREAMING_LIMIT` in `audio_stream.py`
- Removes dependence on the `six` package (we require Python 3.6+ for this agent)
- Minor refactoring of `app.js`.